### PR TITLE
fix: circle-o_24 fix shape and fill-rule (#DS-3034)

### DIFF
--- a/src/svg/circle-o_24.svg
+++ b/src/svg/circle-o_24.svg
@@ -1,1 +1,1 @@
-<svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M21.3 12a9.3 9.3 0 1 1-18.6 0 9.3 9.3 0 0 1 18.6 0Z"/></svg>
+<svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path fill="currentColor" d="M12 20.1a8.1 8.1 0 1 1 0-16.2 8.1 8.1 0 0 1 0 16.2m0 2.4c5.799 0 10.5-4.701 10.5-10.5S17.799 1.5 12 1.5 1.5 6.201 1.5 12 6.201 22.5 12 22.5"/></svg>


### PR DESCRIPTION
Figma icon node didn't have outline stroke. Resulting SVG file and font glyph had the wrong shape

<img width="430" alt="изображение" src="https://github.com/user-attachments/assets/c5779c94-c8ce-4c19-ad8f-8d9668e61f1b">
