### PR TITLE
fix(icons): added xmlns to the root svg (#DS-3446)

### DIFF
--- a/src/svg-sprite.js
+++ b/src/svg-sprite.js
@@ -15,7 +15,8 @@ const config = {
         xmlDeclaration: false,
         doctypeDeclaration: false,
         namespaceIDs: false,
-        dimensionAttributes: false
+        dimensionAttributes: true,
+        rootAttributes: { xmlns: 'http://www.w3.org/2000/svg' }
     },
     mode: {
         symbol: {


### PR DESCRIPTION
## Summary

Seems like we should support it out of the box

https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg

> The xmlns attribute is only required on the outermost svg element of SVG documents, or inside HTML documents with XML serialization. It is unnecessary for inner svg elements or inside HTML documents with HTML serialization.
