### PR TITLE
feat: multiple page icon export (#DS-4126)

### DIFF
--- a/.figmaexportrc.mjs
+++ b/.figmaexportrc.mjs
@@ -12,10 +12,13 @@ const secondaryZoneColorHex = '#E21D03';
 
 /** @type { import('@figma-export/types').ComponentsCommandOptions } */
 const componentOptions = {
-    token: process.env.FIGMA_TOKEN,
     fileId: config.figmaFile.id,
     concurrency: 5,
-    onlyFromPages: [config.figmaFile.page],
+    onlyFromPages: config.figmaFile.pages,
+    filterComponent: (component) => {
+        const name = (component.name || '').trim();
+        return !/^[._]/.test(name);
+    },
     transformers: [
         transformSvgWithSvgo({
             plugins: [
@@ -38,7 +41,6 @@ const componentOptions = {
                     }
                 },
                 {
-                    type: 'visitor',
                     name: 'replace-values',
                     fn: () => {
                         return {
@@ -71,7 +73,8 @@ const componentOptions = {
     ],
     outputters: [
         outputComponentsAsSvg({
-            output: config.output.tempSvg
+            output: config.output.tempSvg,
+            getDirname: ({ pageName }) => pageName
         })
     ]
 };

--- a/config.mjs
+++ b/config.mjs
@@ -1,7 +1,7 @@
 export const config = {
     figmaFile: {
         id: 'WvUarBj8tO256vML4PkBLl',
-        page: '✅ Icons'
+        pages: ['16', '24', '32', '48', '64']
     },
     output: {
         tempSvg: 'temp/svg'

--- a/scripts/check-mapping.mjs
+++ b/scripts/check-mapping.mjs
@@ -4,7 +4,12 @@ import { parse } from 'path';
 async function main() {
     const mapping = JSON.parse(await readFile('./mapping.json', 'utf-8'));
     const svgFileList = (await readdir('./src/svg')).map((svgPath) => parse(svgPath).name);
-    const svgListInMapping = Object.keys(mapping);
+    const svgListInMapping = Object.keys(mapping).sort();
+
+    if (process.argv.includes('--list')) {
+        console.log(svgListInMapping.join('\n'));
+        return;
+    }
 
     const missingFromMapping = svgFileList.filter((svg) => !mapping[svg]);
     const missingFromFiles = svgListInMapping.filter((svg) => !svgFileList.includes(svg));
@@ -13,10 +18,10 @@ async function main() {
         console.error('Issues found with mapping.json:');
 
         if (missingFromMapping.length) {
-            console.error('❌ These SVG files are missing in mapping.json:', missingFromMapping);
+            console.error('❌ These SVG files are missing in mapping.json:\n' + missingFromMapping.join('\n'));
         }
         if (missingFromFiles.length) {
-            console.error('❌ These mappings refer to non-existent SVG files:', missingFromFiles);
+            console.error('❌ These mappings refer to non-existent SVG files:\n' + missingFromFiles.join('\n'));
         }
 
         return;

--- a/scripts/svg-copy-to-src.mjs
+++ b/scripts/svg-copy-to-src.mjs
@@ -22,8 +22,8 @@ const getFiles = async (dirPath, arrayOfFiles = []) => {
     return arrayOfFiles;
 };
 
-const copyIcons = async (destPath, svgDir) => {
-    const iconsList = await getFiles(svgDir);
+const copyIcons = async (destPath, svgRootDir) => {
+    const iconsList = await getFiles(svgRootDir);
 
     for (const item of iconsList) {
         const destFilePath = join(destPath, item.fileName);
@@ -33,15 +33,15 @@ const copyIcons = async (destPath, svgDir) => {
 
 const main = async () => {
     const destDir = join(__dirname, '../src/svg');
-    const svgDir = join(__dirname, `../${config.output.tempSvg}/${config.figmaFile.page}`);
+    const svgRootDir = join(__dirname, `../${config.output.tempSvg}`);
 
     try {
         // Remove and create the destination directory
         await fs.remove(destDir);
         await fs.ensureDir(destDir);
 
-        // Copy icons and info file
-        await copyIcons(destDir, svgDir);
+        // Copy icons from all subfolders inside temp svg directory
+        await copyIcons(destDir, svgRootDir);
 
         console.log('Files successfully copied.');
     } catch (error) {


### PR DESCRIPTION
В Фигме в файле с иконками поменялось устройство. Иконки теперь расположены на разных страницах, а раньше были на одной. Файл прежний.
* Надо экспортировать SVG по страниц с названием 16, 24, 32, 48, 64
* Не экспортировать компоненты имена которых начинаются с «.» или «_»

Все скрипты должны работать:
cборка шрифта, превью, svg-спрайт, публикация в npm, проверка маппинга