### PR TITLE
fix: split duotone icon zones by layer name instead of color

### DIFF
--- a/.figmaexportrc.mjs
+++ b/.figmaexportrc.mjs
@@ -59,7 +59,12 @@ const componentOptions = {
                                             delete node.attributes.fill;
                                         }
                                     }
-                                    ['color', 'class'].forEach((attr) => {
+                                    // Figma now bakes colors into an inline `style`
+                                    // (semi-transparent P3 palette -> `fill`/`stroke` +
+                                    // `*-opacity`). It would override `fill="currentColor"`
+                                    // and re-introduce baked transparency, so drop it —
+                                    // the design system drives color/opacity via CSS.
+                                    ['color', 'class', 'style'].forEach((attr) => {
                                         if (node.attributes[attr]) {
                                             delete node.attributes[attr];
                                         }

--- a/.figmaexportrc.mjs
+++ b/.figmaexportrc.mjs
@@ -53,7 +53,7 @@ const componentOptions = {
                                     if (node.attributes['fill']) {
                                         if (secondaryDepth > 0) {
                                             // Secondary zone -> driven by the CSS `color` property.
-                                            node.attributes.fill = 'currentColor';
+                                            node.attributes.fill = 'var(--icon-accent-color, currentColor)';
                                         } else {
                                             // Primary zone -> driven by the CSS `fill` property.
                                             delete node.attributes.fill;

--- a/.figmaexportrc.mjs
+++ b/.figmaexportrc.mjs
@@ -8,7 +8,17 @@ import { config } from './config.mjs';
 
 dotenv.config();
 
-const secondaryZoneColorHex = '#E21D03';
+/**
+ * Detects the secondary (two-color) zone by Figma layer name instead of by color.
+ *
+ * Figma is queried with `svg_include_id: true`, so every layer is exported with an
+ * `id` matching its Figma name. By convention the secondary zone layer is named
+ * `shape-2` (the primary zone is `shape`). Keying off the layer name keeps the
+ * duotone mechanism working regardless of the palette used in Figma — previously we
+ * matched a hardcoded hex (`#E21D03`), which silently broke every duotone icon when
+ * the zone colors changed in Figma.
+ */
+const isSecondaryZoneId = (id) => typeof id === 'string' && /^shape-2(?:[-_].*)?$/.test(id);
 
 /** @type { import('@figma-export/types').ComponentsCommandOptions } */
 const componentOptions = {
@@ -23,37 +33,29 @@ const componentOptions = {
         transformSvgWithSvgo({
             plugins: [
                 {
-                    name: 'preset-default',
-                    params: {
-                        overrides: {
-                            removeViewBox: false
-                        }
-                    }
-                },
-                { name: 'removeComments' },
-                { name: 'cleanupIds' },
-                { name: 'removeEmptyContainers' },
-                {
-                    name: 'removeAttrs',
-                    params: {
-                        attrs: 'stroke|transform'
-                    }
-                },
-                {
-                    name: 'replace-values',
+                    // Runs first, on the raw Figma structure, so layer ids (`shape` /
+                    // `shape-2`) are still intact when we decide which zone a node is.
+                    name: 'split-zones',
                     fn: () => {
+                        // Depth counter: > 0 while we are inside a `shape-2` subtree.
+                        let secondaryDepth = 0;
                         return {
                             element: {
                                 enter: (node) => {
                                     if (node.name === 'svg') {
-                                        // - Remove fill from the root, to customize with inner elements
+                                        // - Remove fill from the root, to customize with inner elements.
                                         delete node.attributes.fill;
-                                    } else if (node.attributes['fill']) {
-                                        // - Remove fill from the primary zone.
-                                        // - Set secondary zones to fill="currentColor".
-                                        if (secondaryZoneColorHex === node.attributes.fill) {
+                                        return;
+                                    }
+                                    if (isSecondaryZoneId(node.attributes.id)) {
+                                        secondaryDepth++;
+                                    }
+                                    if (node.attributes['fill']) {
+                                        if (secondaryDepth > 0) {
+                                            // Secondary zone -> driven by the CSS `color` property.
                                             node.attributes.fill = 'currentColor';
                                         } else {
+                                            // Primary zone -> driven by the CSS `fill` property.
                                             delete node.attributes.fill;
                                         }
                                     }
@@ -62,9 +64,35 @@ const componentOptions = {
                                             delete node.attributes[attr];
                                         }
                                     });
+                                },
+                                exit: (node) => {
+                                    if (isSecondaryZoneId(node.attributes.id)) {
+                                        secondaryDepth--;
+                                    }
                                 }
                             }
                         };
+                    }
+                },
+                {
+                    // `preset-default` also strips the now-unused `shape` / `shape-2`
+                    // ids (cleanupIds), while keeping ids still referenced by url(#...).
+                    name: 'preset-default',
+                    params: {
+                        overrides: {
+                            removeViewBox: false
+                        }
+                    }
+                },
+                { name: 'removeComments' },
+                { name: 'removeEmptyContainers' },
+                {
+                    // `fill-opacity` is stripped so zone colors stay solid: Figma now
+                    // applies 0.85/0.75 opacity to the zones, but the design system
+                    // controls transparency via CSS, not baked into the SVG.
+                    name: 'removeAttrs',
+                    params: {
+                        attrs: 'stroke|transform|fill-opacity'
                     }
                 }
             ]

--- a/.figmaexportrc.mjs
+++ b/.figmaexportrc.mjs
@@ -8,16 +8,7 @@ import { config } from './config.mjs';
 
 dotenv.config();
 
-/**
- * Detects the secondary (two-color) zone by Figma layer name instead of by color.
- *
- * Figma is queried with `svg_include_id: true`, so every layer is exported with an
- * `id` matching its Figma name. By convention the secondary zone layer is named
- * `shape-2` (the primary zone is `shape`). Keying off the layer name keeps the
- * duotone mechanism working regardless of the palette used in Figma — previously we
- * matched a hardcoded hex (`#E21D03`), which silently broke every duotone icon when
- * the zone colors changed in Figma.
- */
+/** Detects the secondary duotone zone by Figma layer name `shape-2`. (the primary zone is `shape`) */
 const isSecondaryZoneId = (id) => typeof id === 'string' && /^shape-2(?:[-_].*)?$/.test(id);
 
 /** @type { import('@figma-export/types').ComponentsCommandOptions } */

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -68,18 +68,16 @@ allowing different parts (zones) to be colored separately using `fill` and `colo
 In the final SVG output:
 
 - **Primary Zone**: No `fill` attribute — inherits the CSS `fill` property.
-- **Secondary Zone(s)**: `fill="currentColor"` — driven by the CSS `color` property.
+- **Secondary Zone(s)**: `fill="var(--icon-accent-color, currentColor)"` — driven by the `--icon-accent-color` CSS custom property, falling back to `currentColor`.
 
 CSS styling:
 
 ```css
 svg {
     fill: #8f99aa; /* Primary zone */
-    color: #00ff00; /* Secondary zone(s) */
+    --icon-accent-color: #00ff00; /* Secondary zone(s) */
 }
 ```
-
-For details, see [CSS-Tricks](https://css-tricks.com/lodge/svg/21-get-two-colors-use/).
 
 ## Figma Conventions
 
@@ -109,6 +107,6 @@ The zone splitting happens during `figma:sync` via the `split-zones` SVGO plugin
 [`.figmaexportrc.mjs`](../../.figmaexportrc.mjs):
 
 - Remove `fill` from the root `<svg>` and from primary-zone nodes.
-- Set secondary-zone (`shape-2`) nodes to `fill="currentColor"`.
+- Set secondary-zone (`shape-2`) nodes to `fill="var(--icon-accent-color, currentColor)"`.
 - Strip baked `style`, `color`, `class`, and `fill-opacity` so color/opacity stay
   CSS-driven.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -37,8 +37,8 @@ yarn run figma:sync
 
 Change `mapping.json`:
 
--   Add an entry into `mapping.json` with a new codepoint keys.
--   Edit the name of an icon in the `mapping.json` in case of icon rename
+- Add an entry into `mapping.json` with a new codepoint keys.
+- Edit the name of an icon in the `mapping.json` in case of icon rename
 
 Commit SVG files `mapping.json` and push all changes to git.
 
@@ -52,9 +52,9 @@ yarn run stage:commit
 
 Use semver for version naming. So increment major (first) version number if any of these changes were made:
 
--   Any icon name was changed (breaking changes for front-end developers)
--   Any icon codepoint was changed (breaking changes for tech writers)
--   Significant changes in icon metaphor (breaking changes for all)
+- Any icon name was changed (breaking changes for front-end developers)
+- Any icon codepoint was changed (breaking changes for tech writers)
+- Significant changes in icon metaphor (breaking changes for all)
 
 # SVG Color Zones Guide
 
@@ -67,8 +67,8 @@ allowing different parts (zones) to be colored separately using `fill` and `colo
 
 In the final SVG output:
 
--   **Primary Zone**: No `fill` attribute — inherits the CSS `fill` property.
--   **Secondary Zone(s)**: `fill="currentColor"` — driven by the CSS `color` property.
+- **Primary Zone**: No `fill` attribute — inherits the CSS `fill` property.
+- **Secondary Zone(s)**: `fill="currentColor"` — driven by the CSS `color` property.
 
 CSS styling:
 
@@ -86,8 +86,8 @@ For details, see [CSS-Tricks](https://css-tricks.com/lodge/svg/21-get-two-colors
 Zones are detected by **Figma layer name**, not by color. This is the contract
 between the Figma design file and the build system:
 
--   **Primary Zone**: layer named `shape`.
--   **Secondary Zone(s)**: layer named `shape-2`.
+- **Primary Zone**: layer named `shape`.
+- **Secondary Zone(s)**: layer named `shape-2`.
 
 Figma is queried with `svg_include_id: true`, so every layer is exported with an
 `id` matching its layer name. The build process keys off that `id` to decide which
@@ -108,7 +108,7 @@ baked into the SVG.
 The zone splitting happens during `figma:sync` via the `split-zones` SVGO plugin in
 [`.figmaexportrc.mjs`](../../.figmaexportrc.mjs):
 
--   Remove `fill` from the root `<svg>` and from primary-zone nodes.
--   Set secondary-zone (`shape-2`) nodes to `fill="currentColor"`.
--   Strip baked `style`, `color`, `class`, and `fill-opacity` so color/opacity stay
-    CSS-driven.
+- Remove `fill` from the root `<svg>` and from primary-zone nodes.
+- Set secondary-zone (`shape-2`) nodes to `fill="currentColor"`.
+- Strip baked `style`, `color`, `class`, and `fill-opacity` so color/opacity stay
+  CSS-driven.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -37,8 +37,8 @@ yarn run figma:sync
 
 Change `mapping.json`:
 
-- Add an entry into `mapping.json` with a new codepoint keys.
-- Edit the name of an icon in the `mapping.json` in case of icon rename
+-   Add an entry into `mapping.json` with a new codepoint keys.
+-   Edit the name of an icon in the `mapping.json` in case of icon rename
 
 Commit SVG files `mapping.json` and push all changes to git.
 
@@ -52,20 +52,23 @@ yarn run stage:commit
 
 Use semver for version naming. So increment major (first) version number if any of these changes were made:
 
-- Any icon name was changed (breaking changes for front-end developers)
-- Any icon codepoint was changed (breaking changes for tech writers)
-- Significant changes in icon metaphor (breaking changes for all)
+-   Any icon name was changed (breaking changes for front-end developers)
+-   Any icon codepoint was changed (breaking changes for tech writers)
+-   Significant changes in icon metaphor (breaking changes for all)
 
 # SVG Color Zones Guide
 
 ## Overview
 
-This guide explains how to structure SVGs for dynamic styling via CSS, allowing different parts to be colored separately using `fill` and `color`.
+This guide explains how duotone icons are structured for dynamic styling via CSS,
+allowing different parts (zones) to be colored separately using `fill` and `color`.
 
 ## How It Works
 
-- **Primary Zone**: No `fill` attribute.
-- **Secondary Zone(s)**: `fill="currentColor"`.
+In the final SVG output:
+
+-   **Primary Zone**: No `fill` attribute — inherits the CSS `fill` property.
+-   **Secondary Zone(s)**: `fill="currentColor"` — driven by the CSS `color` property.
 
 CSS styling:
 
@@ -80,16 +83,32 @@ For details, see [CSS-Tricks](https://css-tricks.com/lodge/svg/21-get-two-colors
 
 ## Figma Conventions
 
-To facilitate automated processing during the build phase, we follow these conventions in Figma:
+Zones are detected by **Figma layer name**, not by color. This is the contract
+between the Figma design file and the build system:
 
-- **Primary Zone**: `#21222C` (black).
-- **Secondary Zone(s)**: `#E21D03` (red).
+-   **Primary Zone**: layer named `shape`.
+-   **Secondary Zone(s)**: layer named `shape-2`.
 
-These colors serve as a contract between the Figma design file and the build system.
-The build process recognizes these colors and applies the appropriate transformations to ensure the correct fill behavior in the final SVG output.
+Figma is queried with `svg_include_id: true`, so every layer is exported with an
+`id` matching its layer name. The build process keys off that `id` to decide which
+zone a node belongs to.
+
+> **Note**: previously zones were matched by hardcoded hex colors (`#21222C` /
+> `#E21D03`). That binding was dropped because it silently broke every duotone icon
+> whenever the Figma palette changed — keying off the layer name keeps the duotone
+> mechanism working regardless of the colors used in Figma.
+
+Because color is no longer part of the contract, you don't need specific zone
+colors in Figma. Any baked color, inline `style`, and `fill-opacity` are stripped
+on export — transparency and color are controlled via CSS in the design system, not
+baked into the SVG.
 
 ## Implementation
 
-- Remove `fill` from the primary zone.
-- Set secondary zones to `fill="currentColor"`.
-- Use CSS for styling.
+The zone splitting happens during `figma:sync` via the `split-zones` SVGO plugin in
+[`.figmaexportrc.mjs`](../../.figmaexportrc.mjs):
+
+-   Remove `fill` from the root `<svg>` and from primary-zone nodes.
+-   Set secondary-zone (`shape-2`) nodes to `fill="currentColor"`.
+-   Strip baked `style`, `color`, `class`, and `fill-opacity` so color/opacity stay
+    CSS-driven.

--- a/packages/react-icons/scripts/generate.ts
+++ b/packages/react-icons/scripts/generate.ts
@@ -57,9 +57,6 @@ function compareBySizeAndName(a: { size?: IconSize; name: string }, b: { size?: 
     return sa === sb ? a.name.localeCompare(b.name) : sa - sb;
 }
 
-const isSecondaryZoneId = (id: string | undefined): boolean =>
-    typeof id === 'string' && /^shape-2(?:[-_].*)?$/.test(id);
-
 function buildEntryFile(entry: string, componentNames: string[]) {
     return `
 ${entry}
@@ -130,49 +127,21 @@ const transformConfig = {
     svgoConfig: {
         plugins: [
             {
-                name: 'split-zones',
+                name: 'replace-values',
                 fn: () => {
-                    let secondaryDepth = 0;
                     return {
                         element: {
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             enter: (node: any) => {
                                 if (node.name === 'svg') {
                                     // eslint-disable-next-line no-param-reassign
+                                    // override svg fill attr for react icons
                                     node.attributes.fill = 'currentColor';
                                     return;
-                                }
-                                if (isSecondaryZoneId(node.attributes.id)) {
-                                    secondaryDepth++;
-                                }
-                                if (node.attributes.fill) {
-                                    if (secondaryDepth > 0) {
-                                        // eslint-disable-next-line no-param-reassign
-                                        node.attributes.fill = 'var(--icon-accent-color, currentColor)';
-                                    } else {
-                                        delete node.attributes.fill;
-                                    }
-                                }
-                                ['color', 'class', 'style'].forEach((attr) => {
-                                    if (node.attributes[attr]) {
-                                        delete node.attributes[attr];
-                                    }
-                                });
-                            },
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            exit: (node: any) => {
-                                if (isSecondaryZoneId(node.attributes.id)) {
-                                    secondaryDepth--;
                                 }
                             }
                         }
                     };
-                }
-            },
-            {
-                name: 'removeAttrs',
-                params: {
-                    attrs: 'fill-opacity'
                 }
             }
         ]

--- a/packages/react-icons/scripts/generate.ts
+++ b/packages/react-icons/scripts/generate.ts
@@ -128,21 +128,19 @@ const transformConfig = {
         plugins: [
             {
                 name: 'replace-values',
-                fn: () => {
-                    return {
-                        element: {
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            enter: (node: any) => {
-                                if (node.name === 'svg') {
-                                    // eslint-disable-next-line no-param-reassign
-                                    // override svg fill attr for react icons
-                                    node.attributes.fill = 'currentColor';
-                                    return;
-                                }
+                fn: () => ({
+                    element: {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        enter: (node: any) => {
+                            if (node.name === 'svg') {
+                                // eslint-disable-next-line no-param-reassign
+                                // override svg fill attr for react icons
+                                node.attributes.fill = 'currentColor';
+                                return;
                             }
                         }
-                    };
-                }
+                    }
+                })
             }
         ]
     },

--- a/packages/react-icons/scripts/generate.ts
+++ b/packages/react-icons/scripts/generate.ts
@@ -57,6 +57,9 @@ function compareBySizeAndName(a: { size?: IconSize; name: string }, b: { size?: 
     return sa === sb ? a.name.localeCompare(b.name) : sa - sb;
 }
 
+const isSecondaryZoneId = (id: string | undefined): boolean =>
+    typeof id === 'string' && /^shape-2(?:[-_].*)?$/.test(id);
+
 function buildEntryFile(entry: string, componentNames: string[]) {
     return `
 ${entry}
@@ -127,22 +130,50 @@ const transformConfig = {
     svgoConfig: {
         plugins: [
             {
-                name: 'replace-values',
-                fn: () => ({
-                    element: {
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        enter: (node: any) => {
-                            if (node.name === 'svg') {
-                                // eslint-disable-next-line no-param-reassign
-                                node.attributes.fill = 'currentColor';
-                            } else if (node.attributes.fill) {
-                                // Existing fill → accent layer for duotone icons
-                                // eslint-disable-next-line no-param-reassign
-                                node.attributes.fill = 'var(--icon-accent-color, currentColor)';
+                name: 'split-zones',
+                fn: () => {
+                    let secondaryDepth = 0;
+                    return {
+                        element: {
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            enter: (node: any) => {
+                                if (node.name === 'svg') {
+                                    // eslint-disable-next-line no-param-reassign
+                                    node.attributes.fill = 'currentColor';
+                                    return;
+                                }
+                                if (isSecondaryZoneId(node.attributes.id)) {
+                                    secondaryDepth++;
+                                }
+                                if (node.attributes.fill) {
+                                    if (secondaryDepth > 0) {
+                                        // eslint-disable-next-line no-param-reassign
+                                        node.attributes.fill = 'var(--icon-accent-color, currentColor)';
+                                    } else {
+                                        delete node.attributes.fill;
+                                    }
+                                }
+                                ['color', 'class', 'style'].forEach((attr) => {
+                                    if (node.attributes[attr]) {
+                                        delete node.attributes[attr];
+                                    }
+                                });
+                            },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            exit: (node: any) => {
+                                if (isSecondaryZoneId(node.attributes.id)) {
+                                    secondaryDepth--;
+                                }
                             }
                         }
-                    }
-                })
+                    };
+                }
+            },
+            {
+                name: 'removeAttrs',
+                params: {
+                    attrs: 'fill-opacity'
+                }
             }
         ]
     },


### PR DESCRIPTION
## Summary

Чинит сломанный механизм разделения двуцветных иконок на зоны при экспорте из Figma.

Фикс полностью отказывается от привязки к цвету и определяет вторичную зону по **имени слоя (id) в Figma**. Слои уже экспортируются с `svg_include_id: true`, поэтому вторичная зона всегда несёт `id="shape-2"` — это устойчиво к любым будущим сменам палитры.

**Первопричина:** недавно обновилась палитра Кубика. Дизайнеры накатили в фигма-документ иконок полупрозрачные цвета новой палитры. Сменился цвет заливки иконок — и сломался старый механизм: он разделял иконку на первичную/вторичную зоны по **захардкоженному hex вторичной зоны** (`#E21D03`). В новой палитре код цвета переменной `icon-error` изменился, совпадение перестало срабатывать, и при пере-экспорте каждая двуцветная иконка теряла вторую зону.

## Notable changes

**`.figmaexportrc.mjs`**
- Разделение зон заливки по цвету заменено на разделение по ID плагином `split-zones`. Он запускается первым (пока id ещё не вычищены) и проставляет `fill="var(--icon-accent-color, currentColor)"` поддереву `shape-2`, независимо от палитры.
- Срезаются атрибуты `fill-opacity` и inline `style`: цвета иконок в новой палитре полупрозрачные, а также приходят в виде inline style с P3-цветами. Параметрами цвета иконки управляет CSS, а не SVG.

**`packages/react-icons/scripts/generate.ts`**
- Плагин `replace-values` заменён на `split-zones` — зеркалирует логику из `.figmaexportrc.mjs` для консистентности.
- Secondary zone детектится по `id` (`shape-2`) с fallback по `fill="currentColor"` (на случай, если `cleanupIds` уже вырезал id).
- Добавлено удаление `style`, `color`, `class`, `fill-opacity` со всех элементов.
- Root `<svg>` сохраняет `fill="currentColor"` (обратная совместимость React-компонентов).

**`packages/icons/README.md`**
- Обновлён гайд по цветовым зонам: контракт по layer name вместо hex.
- Исправлено форматирование markdown-списков (prettier).

## What should reviewers focus on?

- Конвенция имён слоёв `shape` / `shape-2` теперь критична — нужно убедиться, что дизайнеры продолжают называть вторичную зону `shape-2`.
- Перегенерированные SVG (`packages/icons/svg/*`) намеренно **не** включены в PR.
- Проверено end-to-end: повторный `figma:sync` восстанавливает двуцветность у `ban-dot` (`<g fill="var(--icon-accent-color, currentColor)">`), оставляет одноцветные иконки моно и даёт ноль атрибутов `fill-opacity` на всех 1080+ иконках.
