### PR TITLE
feat: add retry tags for arrow-rotate-right 16 & 24 (#DS-4878)

### DIFF
--- a/mapping.json
+++ b/mapping.json
@@ -3118,7 +3118,7 @@
     "arrow-rotate-right_16": {
         "codepoint": "0xF7F6",
         "description": "",
-        "tags": ["reload", "перезагрузка"]
+        "tags": ["refresh", "reload", "retry", "обновить", "перезагрузка", "повторить"]
     },
     "chevrons-up-down-s_16": {
         "codepoint": "0xF7F7",
@@ -3163,7 +3163,7 @@
     "arrow-rotate-right_24": {
         "codepoint": "0xF7FF",
         "description": "",
-        "tags": ["refresh", "reload", "обновить", "перезагрузка"]
+        "tags": ["refresh", "reload", "retry", "обновить", "перезагрузка", "повторить"]
     },
     "arrow-up-xs_16": {
         "codepoint": "0xF800",


### PR DESCRIPTION
## Summary

Добавляет теги поиска `retry` / `повторить` для иконки `arrow-rotate-right` (размеры 16 и 24) и приводит набор тегов обеих версий к единому виду по образцу Figma-компонента `arrow-rotate-right_16`.

Теги отсортированы по алфавиту (латиница, затем кириллица):
`refresh, reload, retry, обновить, перезагрузка, повторить`

## List of notable changes:

- **added** теги `retry`, `повторить` для `arrow-rotate-right_16` и `arrow-rotate-right_24` в `mapping.json` (#DS-4878)
- **updated** теги `arrow-rotate-right_16`, чтобы набор совпадал с `arrow-rotate-right_24` и с эталоном из Figma (добавлены `refresh`, `обновить`)
- параллельно теги синхронизированы в Figma-компоненте `arrow-rotate-right_24`

## What should reviewers focus on?

- Совпадение набора тегов для размеров 16 и 24.
- Корректность алфавитного порядка тегов.

Задача: DS-4878
