### PR TITLE
feat: update circle-xs icons (#DS-5305)

### DIFF
--- a/packages/icons/svg/circle-xs_16.svg
+++ b/packages/icons/svg/circle-xs_16.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M11 8a3 3 0 1 0-6 0 3 3 0 0 0 6 0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M12 8a4 4 0 1 0-8 0 4 4 0 0 0 8 0"/></svg>

--- a/packages/icons/svg/circle-xs_24.svg
+++ b/packages/icons/svg/circle-xs_24.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M16.5 12a4.5 4.5 0 1 0-9 0 4.5 4.5 0 0 0 9 0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M18 12a6 6 0 1 0-12 0 6 6 0 0 0 12 0"/></svg>


### PR DESCRIPTION
## Summary

Обновлена геометрия иконок `circle-xs_16` и `circle-xs_24` — круг увеличен согласно новой версии компонента в Figma (радиус 3→4 для 16px, 4.5→6 для 24px). Изменение уже утверждено в Figma.

Ноды в Figma:
- circle-xs_16: https://www.figma.com/design/WvUarBj8tO256vML4PkBLl/?node-id=1322-21664
- circle-xs_24: https://www.figma.com/design/WvUarBj8tO256vML4PkBLl/?node-id=42189-16171

## List of notable changes:

- **updated** `packages/icons/svg/circle-xs_16.svg` и `packages/icons/svg/circle-xs_24.svg` — новая геометрия круга из Figma

`mapping.json` не менялся — иконки уже зарегистрированы, теги/кодпоинт не затронуты.

## What should reviewers focus on?

- Соответствие экспортированного SVG актуальной версии в Figma
- Чистота SVG-кода (без лишних `fill`/`fill-opacity`/`stroke`)
- Отсутствие посторонних изменений в `packages/icons/svg/`

DS-5305
